### PR TITLE
Allow selection of tags from coverage data.

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -1,17 +1,27 @@
 /**
  * Generate a tag index from coverage data. This creates an object whose keys
  * are tags and whose values are arrays containing locations.
- * @param {Object} locations Existing coverage data locations.
+ * @param {Array} locations Existing coverage data locations.
+ * @param {Array} select List of tags to get data for.
  * @returns {Object} Locations grouped by tag.
  */
-export default function tags(locations) {
+export default function tags(locations, select) {
   const tags = { };
+  if (select) {
+    select.forEach(entry => {
+      tags[entry] = [];
+    });
+  }
   locations.forEach(location => {
     location.tags.forEach(tag => {
       if (!(tag in tags)) {
-        tags[tag] = [];
+        if (!select) {
+          tags[tag] = [];
+          tags[tag].push(location);
+        }
+      } else {
+        tags[tag].push(location);
       }
-      tags[tag].push(location);
     });
   });
   return tags;

--- a/test/spec/tag.spec.js
+++ b/test/spec/tag.spec.js
@@ -21,3 +21,9 @@ it('should use locations as values from the coverage data', () => {
   expect(result.line).to.be.an.instanceof(Array);
   expect(result.line).to.have.property('length', 99);
 });
+
+it('should select non-existant tags as empty arrays', () => {
+  const result = tags(coverage.locations, [ 'foo' ]);
+  expect(result.foo).to.be.an.instanceof(Array);
+  expect(result.foo).to.have.property('length', 0);
+});


### PR DESCRIPTION
If you need specific tags you can now select for them. Missing tags will simply be converted to empty arrays. This is useful if you wish to assume coverage always includes certain metrics (e.g. `branch` tags).
