### PR TITLE
Avoid division by zero in metrics calculation.

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -4,12 +4,13 @@
  * @returns {Object} Computed information.
  */
 export default function metrics(locations) {
+  const total = locations.length;
   const covered = locations.reduce((sum, { count }) => {
     return (count > 0) ? sum + 1 : sum;
   }, 0);
   return {
-    value: covered / locations.length,
+    value: total ? covered / total : 1,
     passed: covered,
-    total: locations.length,
+    total,
   };
 }

--- a/test/fixture/coverage-no-branch.json
+++ b/test/fixture/coverage-no-branch.json
@@ -1,0 +1,44 @@
+{
+  "src/no-branch.js": {
+    "hash": "c8aef50ee0ed83d5ef92fdd98b091068df692d5a",
+    "path": "src/no-branch.js",
+    "locations": [
+      {
+        "id": 0,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 15
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "tags": [
+          "function"
+        ],
+        "name": "foo",
+        "count": 1
+      },
+      {
+        "id": 1,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 9
+          },
+          "end": {
+            "line": 2,
+            "column": 14
+          }
+        },
+        "tags": [
+          "line",
+          "statement"
+        ],
+        "count": 1
+      }
+    ]
+  }
+}

--- a/test/spec/metrics.spec.js
+++ b/test/spec/metrics.spec.js
@@ -5,13 +5,22 @@ import { expect } from 'chai';
 import tags from '../../src/tags';
 import metrics from '../../src/metrics';
 
-const fixture = path.join(__dirname, '/../fixture/coverage.json');
-const data = JSON.parse(readFileSync(fixture, 'utf8'));
-const coverage = data['src/instrumenter.js'];
-
 it('should calculate correct metrics', () => {
+  const fixture = path.join(__dirname, '/../fixture/coverage.json');
+  const data = JSON.parse(readFileSync(fixture, 'utf8'));
+  const coverage = data['src/instrumenter.js'];
   const result = tags(coverage.locations);
   expect(metrics(result.function)).to.have.property('total', 22);
   expect(metrics(result.line)).to.have.property('total', 99);
   expect(metrics(result.branch)).to.have.property('total', 79);
+});
+
+it('should evaluate metrics value to one when tag is missing', () => {
+  const fixture = path.join(__dirname, '/../fixture/coverage-no-branch.json');
+  const data = JSON.parse(readFileSync(fixture, 'utf8'));
+  const coverage = data['src/no-branch.js'];
+  const result = tags(coverage.locations, [ 'branch' ]);
+  expect(metrics(result.branch)).to.have.property('total', 0);
+  expect(metrics(result.branch)).to.have.property('passed', 0);
+  expect(metrics(result.branch)).to.have.property('value', 1);
 });


### PR DESCRIPTION
Sometimes a selected tag is not present in the covered file (e.g. there are no branches). In this scenario the metrics should evaluate the passed/total ratio to ~~zero~~ one, not NaN.
